### PR TITLE
Add cargo build scripts to compile Mesa.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "osmesa-src"
+version = "12.0.1"
+authors = ["mesa3d maintainers"]
+build = "build.rs"
+repository = "https://github.com/servo/osmesa-src/"
+license = "MIT"
+description = "Mesa is a 3-D graphics library with an API which is very similar to that of OpenGL."
+homepage = "http://mesa3d.org"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let src = env::current_dir().unwrap();
+    let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    // Prevent aclocal being run due to timestamps being messed up by git.
+    // https://stackoverflow.com/questions/18769770/user-of-autotools-generated-tarball-gets-error-message-aclocal-1-13-command-no
+    run(Command::new("touch")
+                .current_dir(src.join("mesa-12.0.1"))
+                .arg("configure.ac")
+                .arg("aclocal.m4")
+                .arg("configure")
+                .arg("Makefile.am")
+                .arg("Makefile.in")
+                .arg("src/compiler/glsl/glcpp/glcpp-lex.c")
+                .arg("src/mesa/program/lex.yy.c"));
+
+    run(Command::new(src.join("mesa-12.0.1/configure"))
+                .current_dir(&dst)
+                .env("PTHREADSTUBS_CFLAGS", ".")
+                .env("PTHREADSTUBS_LIBS", ".")
+                .arg("--disable-gles1")
+                .arg("--disable-gles2")
+                .arg("--disable-dri")
+                .arg("--disable-dri3")
+                .arg("--disable-glx")
+                .arg("--disable-egl")
+                .arg("--disable-driglx-direct")
+                .arg("--enable-gallium-osmesa")
+                .arg("--with-gallium-drivers=swrast")
+                .arg("--disable-llvm-shared-libs"));
+
+    run(Command::new("make")
+                .arg("-j4")
+                .current_dir(&dst));
+}
+
+fn run(cmd: &mut Command) {
+    println!("running: {:?}", cmd);
+    let status = match cmd.status() {
+        Ok(s) => s,
+        Err(e) => panic!("failed to get status: {}", e),
+    };
+    if !status.success() {
+        panic!("failed with: {}", status);
+    }
+}


### PR DESCRIPTION
The configure flags used disable everything possible
except for OSMesa (the offscreen software rendering
portion of Mesa).

If LLVM libraries are detected on the system, the llvmpipe
driver will be built.

However, for Servo testing, we prefer the softpipe driver anyway
since this is faster for CI testing (shader compile times
dominate otherwise when running 10,000 simple tests).

The softpipe driver is always built, regardless of whether
the llvmpipe driver is selected to build.
