### PR TITLE
Fix libOSMesa.so* symlinks on non-bash /bin/sh.

### DIFF
--- a/mesa-12.0.1/install-gallium-links.mk
+++ b/mesa-12.0.1/install-gallium-links.mk
@@ -13,8 +13,8 @@ all-local : .install-gallium-links
 	fi;							\
 	$(MKDIR_P) $$link_dir;					\
 	file_list="$(dri_LTLIBRARIES:%.la=.libs/%.so)";		\
-	file_list+="$(egl_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
-	file_list+="$(lib_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
+	file_list="$$file_list$(egl_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
+	file_list="$$file_list$(lib_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
 	for f in $$file_list; do 				\
 		if test -h .libs/$$f; then			\
 			cp -d $$f $$link_dir;			\

--- a/mesa-12.0.1/src/gallium/targets/osmesa/Makefile.in
+++ b/mesa-12.0.1/src/gallium/targets/osmesa/Makefile.in
@@ -1000,8 +1000,8 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-pkgconfigDATA
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	fi;							\
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	$(MKDIR_P) $$link_dir;					\
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	file_list="$(dri_LTLIBRARIES:%.la=.libs/%.so)";		\
-@BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	file_list+="$(egl_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
-@BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	file_list+="$(lib_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
+@BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	file_list="$$file_list$(egl_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
+@BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	file_list="$$file_list$(lib_LTLIBRARIES:%.la=.libs/%.$(LIB_EXT)*)";	\
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@	for f in $$file_list; do 				\
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@		if test -h .libs/$$f; then			\
 @BUILD_SHARED_TRUE@@HAVE_COMPAT_SYMLINKS_TRUE@			cp -d $$f $$link_dir;			\


### PR DESCRIPTION
On debian, /bin/sh is dash, which doesn't do '+='.  The .mk fix has
been sent upstream to Mesa, but we need to hack the relevant
Makefile.in directly, because we don't run automake.
