### PR TITLE
build: Enable llvm shared libs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: rust
-matrix:
-  include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
-          packages:
-            - clang-3.9
+before_install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo add-apt-repository ppa:llvm-toolchain-precise-3.9 -y
+  - sudo apt-get update -q
+  - sudo apt-get install clang-3.9 -y
 rust:
   - nightly
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:llvm-toolchain-precise-3.9 -y
+  - sudo add-apt-repository 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main' -y
   - sudo apt-get update -q
   - sudo apt-get install clang-3.9 -y
 rust:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: rust
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+          packages:
+            - clang-3.9
 rust:
   - nightly
   - beta

--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,6 @@ fn main() {
                 .arg("--disable-gles1")
                 .arg("--disable-gles2")
                 .arg("--disable-glx")
-                .arg("--disable-llvm-shared-libs")
                 .arg("--with-platforms=")
                 .arg("--enable-gallium-osmesa")
                 .arg("--with-gallium-drivers=swrast"));


### PR DESCRIPTION
Linking statically to LLVM is not recommended anyway.

This fixes #7 