### PR TITLE
Fix compilation on macOS <10.12.

### DIFF
--- a/mesa-src/include/c11/threads_posix.h
+++ b/mesa-src/include/c11/threads_posix.h
@@ -383,6 +383,23 @@ tss_set(tss_t key, void *val)
 /*-------------------- 7.25.7 Time functions --------------------*/
 // 7.25.6.1
 #ifndef HAVE_TIMESPEC_GET
+
+#if defined(__MACH__) && !defined(CLOCK_REALTIME)
+#include <sys/time.h>
+#define CLOCK_REALTIME 0
+// clock_gettime is not implemented on older versions of OS X (< 10.12).
+// If implemented, CLOCK_REALTIME will have already been defined.
+static inline int
+clock_gettime(int clk_id, struct timespec* t) {
+    struct timeval now;
+    int rv = gettimeofday(&now, NULL);
+    if (rv) return rv;
+    t->tv_sec  = now.tv_sec;
+    t->tv_nsec = now.tv_usec * 1000;
+    return 0;
+}
+#endif
+
 static inline int
 timespec_get(struct timespec *ts, int base)
 {

--- a/patches/1.diff
+++ b/patches/1.diff
@@ -1,0 +1,28 @@
+diff --git a/mesa-src/include/c11/threads_posix.h b/mesa-src/include/c11/threads_posix.h
+index 45cb607..a7051b1 100644
+--- a/mesa-src/include/c11/threads_posix.h
++++ b/mesa-src/include/c11/threads_posix.h
+@@ -383,6 +383,23 @@ tss_set(tss_t key, void *val)
+ /*-------------------- 7.25.7 Time functions --------------------*/
+ // 7.25.6.1
+ #ifndef HAVE_TIMESPEC_GET
++
++#if defined(__MACH__) && !defined(CLOCK_REALTIME)
++#include <sys/time.h>
++#define CLOCK_REALTIME 0
++// clock_gettime is not implemented on older versions of OS X (< 10.12).
++// If implemented, CLOCK_REALTIME will have already been defined.
++static inline int
++clock_gettime(int clk_id, struct timespec* t) {
++    struct timeval now;
++    int rv = gettimeofday(&now, NULL);
++    if (rv) return rv;
++    t->tv_sec  = now.tv_sec;
++    t->tv_nsec = now.tv_usec * 1000;
++    return 0;
++}
++#endif
++
+ static inline int
+ timespec_get(struct timespec *ts, int base)
+ {

--- a/tools/update-mesa.sh
+++ b/tools/update-mesa.sh
@@ -30,3 +30,6 @@ popd
 tar -xvf mesa-tmp/mesa-${VERSION}.tar.gz
 mv mesa-${VERSION} mesa-src
 rm -rf mesa-tmp
+
+# apply local patches necessary for Servo's CI
+patch -i patches/1.diff -p1


### PR DESCRIPTION
10.12 was released in 2016, so it's not clear to me that it's worth trying to submit this upstream.