### PR TITLE
Exclude the cross-file and force-enable LLVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: rust
-dist: xenial
+dist: bionic
 before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main' -y
   - sudo apt-get update -q
-  - sudo apt-get install clang-3.9 llvm-3.9-dev llvm-3.9-runtime python3-pip python3-setuptools -y
-  - export LLVM_CONFIG=llvm-config-3.9
-  - pip3 install mako meson wheel ninja
+  - sudo apt-get install clang-10 llvm-10-runtime llvm-10-dev llvm-10-tools python3-pip python3-setuptools -y
+  - pip3 install mako meson ninja
 rust:
   - nightly
   - beta

--- a/build.rs
+++ b/build.rs
@@ -11,21 +11,10 @@ fn main() {
     if !dst.join("build.ninja").exists() {
         let mut cmd = Command::new("meson");
 
-        if env::var_os("HOST") != env::var_os("TARGET") {
-            let cross_file = match env::var_os("CARGO_CFG_TARGET_VENDOR")
-                .unwrap()
-                .into_string()
-                .unwrap()
-                .as_str()
-            {
-                "apple" => Some("darwin.meson"),
-                _ => None,
-            };
-            if let Some(cross_file) = cross_file {
-                cmd
-                    .arg("--cross-file")
-                    .arg(cargo_dir.join("crossfiles").join(cross_file));
-            }
+        if let Some(cross_path) = env::var_os("MESON_CROSSFILE") {
+            cmd
+                .arg("--cross-file")
+                .arg(cross_path);
         }
 
         run(cmd
@@ -42,7 +31,8 @@ fn main() {
             .arg("-Dosmesa=gallium")
             .arg("-Degl=disabled")
             .arg("-Dgbm=disabled")
-            .arg("-Dglx=disabled"));
+            .arg("-Dglx=disabled")
+            .arg("-Dllvm=enabled"));
     }
 
     run(Command::new("ninja").current_dir(&dst));

--- a/crossfiles/darwin.meson
+++ b/crossfiles/darwin.meson
@@ -1,5 +1,0 @@
-[host_machine]
-system = 'darwin'
-cpu_family = 'x86_64'
-cpu = 'i686'
-endian = 'little'


### PR DESCRIPTION
In order for it to compile on FF CI, we have to provide the `llvm-config` path. This means, being very tied to the environment of execution, and keeping such a cross file in this repo is confusing.