### PR TITLE
Use InstSimplify pass instead of ConstantProgagation

### DIFF
--- a/mesa-src/src/gallium/auxiliary/gallivm/lp_bld_init.c
+++ b/mesa-src/src/gallium/auxiliary/gallivm/lp_bld_init.c
@@ -169,7 +169,11 @@ create_pass_manager(struct gallivm_state *gallivm)
        */
       LLVMAddReassociatePass(gallivm->passmgr);
       LLVMAddPromoteMemoryToRegisterPass(gallivm->passmgr);
+#if LLVM_VERSION_MAJOR <= 11
       LLVMAddConstantPropagationPass(gallivm->passmgr);
+#else
+      LLVMAddInstructionSimplifyPass(gallivm->passmgr);
+#endif
       LLVMAddInstructionCombiningPass(gallivm->passmgr);
       LLVMAddGVNPass(gallivm->passmgr);
    }


### PR DESCRIPTION
The constantPropagation pass was removed in LLVM 12.

Backported from
https://gitlab.freedesktop.org/mesa/mesa/-/commit/52cac068621a5998f486f8e44f9c2d9d045d1c31
https://gitlab.freedesktop.org/mesa/mesa/-/commit/1d018bc7fde744b5fc71108887a51e5bfaff8776